### PR TITLE
Add protobuf skeleton

### DIFF
--- a/karapace/compatibility/__init__.py
+++ b/karapace/compatibility/__init__.py
@@ -139,11 +139,20 @@ def check_compatibility(
                 writer=old_schema.schema,
             )
         elif compatibility_mode in {CompatibilityModes.FORWARD, CompatibilityModes.FORWARD_TRANSITIVE}:
-            result = check_protobuf_compatibility(reader=old_schema.schema, writer=new_schema.schema)
+            result = check_protobuf_compatibility(
+                reader=old_schema.schema,
+                writer=new_schema.schema,
+            )
 
         elif compatibility_mode in {CompatibilityModes.FULL, CompatibilityModes.FULL_TRANSITIVE}:
-            result = check_protobuf_compatibility(reader=new_schema.schema, writer=old_schema.schema)
-            result = result.merged_with(check_protobuf_compatibility(reader=old_schema.schema, writer=new_schema.schema))
+            result = check_protobuf_compatibility(
+                reader=new_schema.schema,
+                writer=old_schema.schema,
+            )
+            result = result.merged_with(check_protobuf_compatibility(
+                reader=old_schema.schema,
+                writer=new_schema.schema,
+            ))
 
     else:
         result = SchemaCompatibilityResult.incompatible(

--- a/karapace/compatibility/__init__.py
+++ b/karapace/compatibility/__init__.py
@@ -11,8 +11,8 @@ from karapace.avro_compatibility import (
     SchemaIncompatibilityType
 )
 from karapace.compatibility.jsonschema.checks import compatibility as jsonschema_compatibility
-from karapace.schema_reader import SchemaType, TypedSchema
 from karapace.protobuf_compatibility import check_protobuf_schema_compatibility
+from karapace.schema_reader import SchemaType, TypedSchema
 
 import logging
 
@@ -61,6 +61,7 @@ def check_avro_compatibility(reader_schema, writer_schema) -> SchemaCompatibilit
 
 def check_jsonschema_compatibility(reader: Draft7Validator, writer: Draft7Validator) -> SchemaCompatibilityResult:
     return jsonschema_compatibility(reader, writer)
+
 
 def check_protobuf_compatibility(reader_schema, writer_schema) -> SchemaCompatibilityResult:
     result = check_protobuf_schema_compatibility(reader_schema, writer_schema)
@@ -141,7 +142,7 @@ def check_compatibility(
         elif compatibility_mode in {CompatibilityModes.FULL, CompatibilityModes.FULL_TRANSITIVE}:
             result = check_protobuf_compatibility(reader_schema=new_schema.schema, writer_schema=old_schema.schema)
             result = result.merged_with(
-                        check_protobuf_compatibility(reader_schema=old_schema.schema, writer_schema=new_schema.schema)
+                check_protobuf_compatibility(reader_schema=old_schema.schema, writer_schema=new_schema.schema)
             )
 
     else:

--- a/karapace/compatibility/protobuf/checks.py
+++ b/karapace/compatibility/protobuf/checks.py
@@ -2,17 +2,6 @@
 from karapace.avro_compatibility import SchemaCompatibilityResult
 
 
-def parse_protobuf_schema_definition(schema_definition: str) -> str:
-    """ Parses and validates `schema_definition`.
-
-    Raises:
-        Nothing yet.
-
-    """
-
-    return schema_definition
-
-
 def check_protobuf_schema_compatibility(reader: str, writer: str) -> SchemaCompatibilityResult:
     # TODO: PROTOBUF* for investigation purposes yet
 

--- a/karapace/kafka_rest_apis/__init__.py
+++ b/karapace/kafka_rest_apis/__init__.py
@@ -25,9 +25,10 @@ import time
 RECORD_KEYS = ["key", "value", "partition"]
 PUBLISH_KEYS = {"records", "value_schema", "value_schema_id", "key_schema", "key_schema_id"}
 RECORD_CODES = [42201, 42202]
-KNOWN_FORMATS = {"json", "avro", "binary"}
+KNOWN_FORMATS = {"json", "avro", "protobuf", "binary"}
 OFFSET_RESET_STRATEGIES = {"latest", "earliest"}
-SCHEMA_MAPPINGS = {"avro": SchemaType.AVRO, "jsonschema": SchemaType.JSONSCHEMA}
+# TODO: PROTOBUF* check schema mapping
+SCHEMA_MAPPINGS = {"avro": SchemaType.AVRO, "jsonschema": SchemaType.JSONSCHEMA, "protobuf": SchemaType.PROTOBUF}
 TypedConsumer = namedtuple("TypedConsumer", ["consumer", "serialization_format", "config"])
 
 

--- a/karapace/protobuf/schema.py
+++ b/karapace/protobuf/schema.py
@@ -4,5 +4,5 @@ class ProtobufSchema:
     def __init__(self, schema: str):
         self.schema = schema
 
-    def to_json(self):
+    def __str__(self) -> str:
         return self.schema

--- a/karapace/protobuf/schema.py
+++ b/karapace/protobuf/schema.py
@@ -1,0 +1,8 @@
+class ProtobufSchema:
+    schema: str
+
+    def __init__(self, schema: str):
+        self.schema = schema
+
+    def to_json(self):
+        return self.schema

--- a/karapace/protobuf/utils.py
+++ b/karapace/protobuf/utils.py
@@ -1,0 +1,3 @@
+def protobuf_encode(a: str) -> str:
+    # TODO: PROTOBUF
+    return a

--- a/karapace/protobuf_compatibility.py
+++ b/karapace/protobuf_compatibility.py
@@ -1,0 +1,22 @@
+# TODO: PROTOBUF* this functionality must be implemented
+from karapace.avro_compatibility import SchemaCompatibilityResult
+
+
+def parse_protobuf_schema_definition(schema_definition: str) -> str:
+    """ Parses and validates `schema_definition`.
+
+    Raises:
+        Nothing yet.
+
+    """
+
+    return schema_definition
+
+
+def check_protobuf_schema_compatibility(reader: str, writer: str) -> SchemaCompatibilityResult:
+    # TODO: PROTOBUF* for investigation purposes yet
+
+    if writer != reader:
+        return SchemaCompatibilityResult.compatible()
+
+    return SchemaCompatibilityResult.compatible()

--- a/karapace/schema_reader.py
+++ b/karapace/schema_reader.py
@@ -23,7 +23,6 @@ from typing import Dict
 
 import json
 import logging
-import sys
 import time
 
 log = logging.getLogger(__name__)
@@ -89,8 +88,8 @@ class TypedSchema:
         try:
             return TypedSchema(parse_protobuf_schema_definition(schema_str), SchemaType.PROTOBUF, schema_str)
         # TypeError - Raised when the user forgets to encode the schema as a string.
-        except Exception as e:  # FIXME: bare except
-            print("Unexpected error:", sys.exc_info()[0])
+        except Exception as e:  # FIXME: bare exception
+            log.exception("Unexpected error:")
             raise InvalidSchema from e
 
     @staticmethod
@@ -108,18 +107,16 @@ class TypedSchema:
             return self.schema.schema
         if isinstance(self.schema, AvroSchema):
             return self.schema.to_json(names=None)
-        if isinstance(self.schema, ProtobufSchema):
-            return self.schema.to_json()
         return self.schema
 
     def __str__(self) -> str:
         if isinstance(self.schema, ProtobufSchema):
-            return self.schema.to_json()
+            return str(self.schema)
         return json_encode(self.to_json(), compact=True)
 
     def __repr__(self):
         if isinstance(self.schema, ProtobufSchema):
-            return f"TypedSchema(type={self.schema_type}, schema={json_encode(self.to_json())})"
+            return f"TypedSchema(type={self.schema_type}, schema={str(self)})"
         return f"TypedSchema(type={self.schema_type}, schema={json_encode(self.to_json())})"
 
     def __eq__(self, other):

--- a/karapace/schema_reader.py
+++ b/karapace/schema_reader.py
@@ -15,7 +15,6 @@ from kafka.errors import NoBrokersAvailable, NodeNotReadyError, TopicAlreadyExis
 from karapace import constants
 from karapace.avro_compatibility import parse_avro_schema_definition
 from karapace.protobuf.schema import ProtobufSchema
-from karapace.protobuf.utils import protobuf_encode
 from karapace.statsd import StatsClient
 from karapace.utils import json_encode, KarapaceKafkaClient
 from queue import Queue
@@ -101,7 +100,6 @@ class TypedSchema:
         if schema_type is SchemaType.JSONSCHEMA:
             return TypedSchema.parse_json(schema_str)
         if schema_type is SchemaType.PROTOBUF:
-            sys.stderr.write(f"ZVALA1: {TypedSchema.parse_protobuf(schema_str)}")
             return TypedSchema.parse_protobuf(schema_str)
         raise InvalidSchema(f"Unknown parser {schema_type} for {schema_str}")
 
@@ -117,14 +115,12 @@ class TypedSchema:
     def __str__(self) -> str:
         if isinstance(self.schema, ProtobufSchema):
             return self.schema.to_json()
-        else:
-            return json_encode(self.to_json(), compact=True)
+        return json_encode(self.to_json(), compact=True)
 
     def __repr__(self):
         if isinstance(self.schema, ProtobufSchema):
             return f"TypedSchema(type={self.schema_type}, schema={json_encode(self.to_json())})"
-        else:
-            return f"TypedSchema(type={self.schema_type}, schema={json_encode(self.to_json())})"
+        return f"TypedSchema(type={self.schema_type}, schema={json_encode(self.to_json())})"
 
     def __eq__(self, other):
         return isinstance(other, TypedSchema) and self.__str__() == other.__str__() and self.schema_type is other.schema_type

--- a/karapace/schema_reader.py
+++ b/karapace/schema_reader.py
@@ -4,8 +4,6 @@ karapace - Kafka schema reader
 Copyright (c) 2019 Aiven Ltd
 See LICENSE for details
 """
-import sys
-
 from avro.schema import Schema as AvroSchema, SchemaParseException
 from enum import Enum, unique
 from json import JSONDecodeError
@@ -25,6 +23,7 @@ from typing import Dict
 
 import json
 import logging
+import sys
 import time
 
 log = logging.getLogger(__name__)

--- a/karapace/schema_registry_apis.py
+++ b/karapace/schema_registry_apis.py
@@ -232,7 +232,8 @@ class KarapaceSchemaRegistry(KarapaceBase):
         key = '{{"subject":"{}","magic":0,"keytype":"DELETE_SUBJECT"}}'.format(subject)
         value = '{{"subject":"{}","version":{}}}'.format(subject, version)
         return self.send_kafka_message(key, value)
-# TODO: PROTOBUF add protobuf compatibility_check
+
+    # TODO: PROTOBUF add protobuf compatibility_check
     async def compatibility_check(self, content_type, *, subject, version, request):
         """Check for schema compatibility"""
         body = request.json

--- a/karapace/schema_registry_apis.py
+++ b/karapace/schema_registry_apis.py
@@ -232,7 +232,7 @@ class KarapaceSchemaRegistry(KarapaceBase):
         key = '{{"subject":"{}","magic":0,"keytype":"DELETE_SUBJECT"}}'.format(subject)
         value = '{{"subject":"{}","version":{}}}'.format(subject, version)
         return self.send_kafka_message(key, value)
-
+# TODO: PROTOBUF add protobuf compatibility_check
     async def compatibility_check(self, content_type, *, subject, version, request):
         """Check for schema compatibility"""
         body = request.json
@@ -543,7 +543,7 @@ class KarapaceSchemaRegistry(KarapaceBase):
 
     def _validate_schema_type(self, content_type, body) -> None:
         schema_type = SchemaType(body.get("schemaType", SchemaType.AVRO.value))
-        if schema_type not in {SchemaType.JSONSCHEMA, SchemaType.AVRO}:
+        if schema_type not in {SchemaType.JSONSCHEMA, SchemaType.AVRO, SchemaType.PROTOBUF}:
             self.r(
                 body={
                     "error_code": SchemaErrorCodes.HTTP_UNPROCESSABLE_ENTITY.value,

--- a/karapace/serialization.py
+++ b/karapace/serialization.py
@@ -12,7 +12,6 @@ import avro
 import io
 import logging
 import struct
-import sys
 
 log = logging.getLogger(__name__)
 

--- a/karapace/serialization.py
+++ b/karapace/serialization.py
@@ -135,6 +135,7 @@ class SchemaRegistrySerializerDeserializer:
             namespace = schema_typed.schema.namespace
         if schema_type is SchemaType.JSONSCHEMA:
             namespace = schema_typed.to_json().get("namespace", "dummy")
+        # TODO: PROTOBUF* Seems protobuf does not use namespaces in terms of AVRO
         return f"{self.subject_name_strategy(topic_name, namespace)}-{subject_type}"
 
     async def get_schema_for_subject(self, subject: str) -> TypedSchema:
@@ -184,6 +185,10 @@ def read_value(schema: TypedSchema, bio: io.BytesIO):
         except ValidationError as e:
             raise InvalidPayload from e
         return value
+    if schema.schema_type is SchemaType.PROTOBUF:
+        # TODO: PROTOBUF* we need use protobuf validator there
+        value = bio.read()
+        return value
     raise ValueError("Unknown schema type")
 
 
@@ -197,6 +202,10 @@ def write_value(schema: TypedSchema, bio: io.BytesIO, value: dict):
         except ValidationError as e:
             raise InvalidPayload from e
         bio.write(json_encode(value, binary=True))
+    elif schema.schema_type is SchemaType.PROTOBUF:
+        # TODO: PROTOBUF* we need use protobuf validator there
+        bio.write(value)
+
     else:
         raise ValueError("Unknown schema type")
 

--- a/karapace/serialization.py
+++ b/karapace/serialization.py
@@ -72,7 +72,7 @@ class SchemaRegistryClient:
 
     async def post_new_schema(self, subject: str, schema: TypedSchema) -> int:
         if schema.schema_type is SchemaType.PROTOBUF:
-            payload = {"schema": schema.to_json(), "schemaType": schema.schema_type.value}
+            payload = {"schema": str(schema), "schemaType": schema.schema_type.value}
         else:
             payload = {"schema": json_encode(schema.to_json()), "schemaType": schema.schema_type.value}
         result = await self.client.post(f"subjects/{quote(subject)}/versions", json=payload)

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -15,3 +15,17 @@ async def test_remote_client(registry_async_client):
     stored_id, stored_schema = await reg_cli.get_latest_schema(subject)
     assert stored_id == sc_id
     assert stored_schema == schema_avro
+
+
+async def test_remote_client_protobuf(registry_async_client):
+    schema_avro = TypedSchema.parse(SchemaType.PROTOBUF, schema_avro_json)
+    reg_cli = SchemaRegistryClient()
+    reg_cli.client = registry_async_client
+    subject = new_random_name("subject")
+    sc_id = await reg_cli.post_new_schema(subject, schema_avro)
+    assert sc_id >= 0
+    stored_schema = await reg_cli.get_schema_for_id(sc_id)
+    assert stored_schema == schema_avro, f"stored schema {stored_schema.to_json()} is not {schema_avro.to_json()}"
+    stored_id, stored_schema = await reg_cli.get_latest_schema(subject)
+    assert stored_id == sc_id
+    assert stored_schema == schema_avro

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -15,6 +15,3 @@ async def test_remote_client(registry_async_client):
     stored_id, stored_schema = await reg_cli.get_latest_schema(subject)
     assert stored_id == sc_id
     assert stored_schema == schema_avro
-
-
-

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -1,6 +1,6 @@
 from karapace.schema_reader import SchemaType, TypedSchema
 from karapace.serialization import SchemaRegistryClient
-from tests.utils import new_random_name, schema_avro_json, schema_protobuf_plain
+from tests.utils import new_random_name, schema_avro_json
 
 
 async def test_remote_client(registry_async_client):
@@ -15,17 +15,3 @@ async def test_remote_client(registry_async_client):
     stored_id, stored_schema = await reg_cli.get_latest_schema(subject)
     assert stored_id == sc_id
     assert stored_schema == schema_avro
-
-
-async def test_remote_client_protobuf(registry_async_client):
-    schema_protobuf = TypedSchema.parse(SchemaType.PROTOBUF, schema_protobuf_plain)
-    reg_cli = SchemaRegistryClient()
-    reg_cli.client = registry_async_client
-    subject = new_random_name("subject")
-    sc_id = await reg_cli.post_new_schema(subject, schema_protobuf)
-    assert sc_id >= 0
-    stored_schema = await reg_cli.get_schema_for_id(sc_id)
-    assert stored_schema == schema_protobuf, f"stored schema {stored_schema} is not {schema_protobuf}"
-    stored_id, stored_schema = await reg_cli.get_latest_schema(subject)
-    assert stored_id == sc_id
-    assert stored_schema == schema_protobuf

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -17,15 +17,4 @@ async def test_remote_client(registry_async_client):
     assert stored_schema == schema_avro
 
 
-async def test_remote_client_protobuf(registry_async_client):
-    schema_avro = TypedSchema.parse(SchemaType.PROTOBUF, schema_avro_json)
-    reg_cli = SchemaRegistryClient()
-    reg_cli.client = registry_async_client
-    subject = new_random_name("subject")
-    sc_id = await reg_cli.post_new_schema(subject, schema_avro)
-    assert sc_id >= 0
-    stored_schema = await reg_cli.get_schema_for_id(sc_id)
-    assert stored_schema == schema_avro, f"stored schema {stored_schema.to_json()} is not {schema_avro.to_json()}"
-    stored_id, stored_schema = await reg_cli.get_latest_schema(subject)
-    assert stored_id == sc_id
-    assert stored_schema == schema_avro
+

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -1,6 +1,6 @@
 from karapace.schema_reader import SchemaType, TypedSchema
 from karapace.serialization import SchemaRegistryClient
-from tests.utils import new_random_name, schema_avro_json
+from tests.utils import new_random_name, schema_avro_json, schema_protobuf_plain
 
 
 async def test_remote_client(registry_async_client):
@@ -15,3 +15,17 @@ async def test_remote_client(registry_async_client):
     stored_id, stored_schema = await reg_cli.get_latest_schema(subject)
     assert stored_id == sc_id
     assert stored_schema == schema_avro
+
+
+async def test_remote_client_protobuf(registry_async_client):
+    schema_protobuf = TypedSchema.parse(SchemaType.PROTOBUF, schema_protobuf_plain)
+    reg_cli = SchemaRegistryClient()
+    reg_cli.client = registry_async_client
+    subject = new_random_name("subject")
+    sc_id = await reg_cli.post_new_schema(subject, schema_protobuf)
+    assert sc_id >= 0
+    stored_schema = await reg_cli.get_schema_for_id(sc_id)
+    assert stored_schema == schema_protobuf, f"stored schema {stored_schema} is not {schema_protobuf}"
+    stored_id, stored_schema = await reg_cli.get_latest_schema(subject)
+    assert stored_id == sc_id
+    assert stored_schema == schema_protobuf

--- a/tests/integration/test_client_protobuf.py
+++ b/tests/integration/test_client_protobuf.py
@@ -1,0 +1,18 @@
+from karapace.schema_reader import SchemaType, TypedSchema
+from karapace.serialization import SchemaRegistryClient
+from tests.schemas.protobuf import schema_protobuf_plain
+from tests.utils import new_random_name
+
+
+async def test_remote_client_protobuf(registry_async_client):
+    schema_protobuf = TypedSchema.parse(SchemaType.PROTOBUF, schema_protobuf_plain)
+    reg_cli = SchemaRegistryClient()
+    reg_cli.client = registry_async_client
+    subject = new_random_name("subject")
+    sc_id = await reg_cli.post_new_schema(subject, schema_protobuf)
+    assert sc_id >= 0
+    stored_schema = await reg_cli.get_schema_for_id(sc_id)
+    assert stored_schema == schema_protobuf, f"stored schema {stored_schema} is not {schema_protobuf}"
+    stored_id, stored_schema = await reg_cli.get_latest_schema(subject)
+    assert stored_id == sc_id
+    assert stored_schema == schema_protobuf

--- a/tests/schemas/protobuf.py
+++ b/tests/schemas/protobuf.py
@@ -1,0 +1,11 @@
+schema_protobuf_plain = """
+syntax = "proto3";
+package com.codingharbour.protobuf;
+
+option java_outer_classname = "SimpleMessageProtos";
+message SimpleMessage {
+  string content = 1;
+  string date_time = 2;
+  string content2 = 3;
+}
+"""

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -42,21 +42,7 @@ schema_avro_json = json.dumps({
     }]
 })
 
-schema_protobuf_json = json.dumps({
-    "namespace": "example.avro",
-    "type": "record",
-    "name": "example.avro.User",
-    "fields": [{
-        "name": "name",
-        "type": "string"
-    }, {
-        "name": "favorite_number",
-        "type": "int"
-    }, {
-        "name": "favorite_color",
-        "type": "string"
-    }]
-})
+
 
 test_objects_jsonschema = [{"foo": 100}, {"foo": 200}]
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -42,6 +42,10 @@ schema_avro_json = json.dumps({
     }]
 })
 
+schema_protobuf_plain = "syntax = \"proto3\";\npackage com.codingharbour.protobuf;\n\noption java_outer_classname = \""\
+                        "SimpleMessageProtos\";\n\nmessage SimpleMessage {\n  string content = 1;\n"\
+                        "  string date_time = 2;\n  string content2 = 3;\n}\n"
+
 test_objects_jsonschema = [{"foo": 100}, {"foo": 200}]
 
 test_objects_avro = [

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -42,10 +42,6 @@ schema_avro_json = json.dumps({
     }]
 })
 
-schema_protobuf_plain = "syntax = \"proto3\";\npackage com.codingharbour.protobuf;\n\noption java_outer_classname = \""\
-                        "SimpleMessageProtos\";\n\nmessage SimpleMessage {\n  string content = 1;\n"\
-                        "  string date_time = 2;\n  string content2 = 3;\n}\n"
-
 test_objects_jsonschema = [{"foo": 100}, {"foo": 200}]
 
 test_objects_avro = [

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -42,6 +42,22 @@ schema_avro_json = json.dumps({
     }]
 })
 
+schema_protobuf_json = json.dumps({
+    "namespace": "example.avro",
+    "type": "record",
+    "name": "example.avro.User",
+    "fields": [{
+        "name": "name",
+        "type": "string"
+    }, {
+        "name": "favorite_number",
+        "type": "int"
+    }, {
+        "name": "favorite_color",
+        "type": "string"
+    }]
+})
+
 test_objects_jsonschema = [{"foo": 100}, {"foo": 200}]
 
 test_objects_avro = [

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -42,8 +42,6 @@ schema_avro_json = json.dumps({
     }]
 })
 
-
-
 test_objects_jsonschema = [{"foo": 100}, {"foo": 200}]
 
 test_objects_avro = [


### PR DESCRIPTION
**Description**

Added initial protobuf support with stubs for schema CRUD operations

Added a test to integration tests which POST/GET a protobuf schema to karapace as plain text without parsing and processing. (test_remote_client_protobuf) 

Integration test can be executed by :

make integrationtest

Actual schema parser development is in progress and goes in another branch
