### PR TITLE
Add support for new configs including advertised_port and use_secured_proxy

### DIFF
--- a/karapace/config.py
+++ b/karapace/config.py
@@ -30,6 +30,8 @@ DEFAULTS = {
     "group_id": "schema-registry",
     "host": "127.0.0.1",
     "port": 8081,
+    "advertised_port": None,
+    "use_secured_proxy": False,
     "server_tls_certfile": None,
     "server_tls_keyfile": None,
     "registry_host": "127.0.0.1",

--- a/karapace/kafka_rest_apis/consumer_manager.py
+++ b/karapace/kafka_rest_apis/consumer_manager.py
@@ -29,7 +29,11 @@ TypedConsumer = namedtuple("TypedConsumer", ["consumer", "serialization_format",
 class ConsumerManager:
     def __init__(self, config: dict) -> None:
         self.config = config
-        self.hostname = f"http://{self.config['advertised_hostname']}:{self.config['port']}"
+        self.protocol = 'https' if self.config['use_secured_proxy'] else 'http'
+        if self.config['advertised_port'] is None:
+            self.hostname = f"{self.protocol}://{self.config['advertised_hostname']}:{self.config['port']}"
+        else:
+            self.hostname = f"{self.protocol}://{self.config['advertised_hostname']}:{self.config['advertised_port']}"
         self.log = logging.getLogger("RestConsumerManager")
         self.deserializer = SchemaRegistryDeserializer(config=config)
         self.consumers = {}


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does
I am currently using a reverse proxy server (Nginx) in front of Karapace Rest Proxy. I am using the docker environment, and Nginx and Karapace are listening on different ports. When creating a consumer using Karapace:

```
curl -XPOST https://<domain>:<nginx-port>/consumers/consumer1 -u <username>:<password> \
--data '{"name": "my_consumer_instance", "format": "json", "auto.offset.reset": "earliest"}' \
--header "Content-Type: application/vnd.kafka.json.v2+json
```
The `base_uri` in response just gives me the karapace's port rather than the nginx port.
The response:
`{"base_uri":"http://<ip>:<karapace-port>/consumers/consumer1/instances/my_consumer_instance","instance_id":"my_consumer_instance"}` 
Also, the protocol in the base_uri response is using http as default and cannot be changed because there are no configs to change that. 
This PR adds support for new configs including advertised_port and use_secured_proxy to solve these problems. 

<!-- Provide a small sentence that summarizes the change. -->
Add new configs in karapace/config.py. And use them in karapace/kafka_rest_apis/consumer_manager.py if these configs are set. 

<!-- Provide the issue number below if it exists. -->
References: INS-18187

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
